### PR TITLE
TOOLS-1934 feat: workflow for drupal automatic update

### DIFF
--- a/.github/workflows/update_drupal_fingerprint.yml
+++ b/.github/workflows/update_drupal_fingerprint.yml
@@ -61,17 +61,14 @@ jobs:
         id: cpr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore[bot]: update Drupal fingerprints with new versions"
-          title: "Update Drupal Fingerprints - New Versions Detected"
+          commit-message: "chore[bot]: update drupal fingerprints"
+          title: "chore[bot]: update drupal fingerprints"
           body: |
             ## Automated Drupal Fingerprint Update
 
             This PR was automatically created because new Drupal versions were detected.
 
-            ### Changes:
-            - Updated Drupal version fingerprints
-
-            Please review and merge if the changes look correct.
+            Please check the versions.xml file to make sure the format is fine and merge if everything is OK.
           branch: update-drupal-fingerprints-${{ github.run_number }}
           base: ${{ github.event.repository.default_branch }}
           delete-branch: true

--- a/.github/workflows/update_drupal_fingerprint.yml
+++ b/.github/workflows/update_drupal_fingerprint.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    # Run every Monday at 10:00 AM Romania time (8:00 AM UTC)
-    - cron: "0 8 * * 1"
+    # Run every Monday at 10:00 AM EEST and 9:00 AM EET (7:00 AM UTC)
+    - cron: "0 7 * * 1"
 
 jobs:
   update_drupal_fingerprint:
@@ -40,10 +40,10 @@ jobs:
         run: |
           if ! git diff --exit-code --quiet dscan/plugins/drupal/versions.xml; then
             echo "changes=true" >> $GITHUB_OUTPUT
-            echo "Changes detected in dscan/plugins/drupal/versions.xml"
+            echo "Changes detected in dscan/plugins/drupal/versions.xml, will create a pull request."
           else
             echo "changes=false" >> $GITHUB_OUTPUT
-            echo "No changes detected in dscan/plugins/drupal/versions.xml"
+            echo "No changes detected in dscan/plugins/drupal/versions.xml, will not create a pull request"
           fi
 
       - name: Setup GPG
@@ -69,13 +69,14 @@ jobs:
             This PR was automatically created because new Drupal versions were detected.
 
             Please check the versions.xml file to make sure the format is fine and merge if everything is OK.
+            After merging, the FORCE_DRUPAL_BUILD also needs to be updated to true, atm it is not done automatically.
           branch: update-drupal-fingerprints-${{ github.run_number }}
           base: ${{ github.event.repository.default_branch }}
           delete-branch: true
           add-paths: |
             dscan/plugins/drupal/versions.xml
-          committer: Drupal Update Automation <108682220+mihai-pasca@users.noreply.github.com>
-          author: Drupal Update Automation <108682220+mihai-pasca@users.noreply.github.com>
+          committer: ${{ vars.COMMIT_AUTHOR }}
+          author: ${{ vars.COMMIT_AUTHOR }}
           signoff: true
 
       - name: Send GitHub Action trigger data to Slack workflow
@@ -89,14 +90,15 @@ jobs:
             {
               "link": ${{ toJson(steps.cpr.outputs.pull-request-url) }}
             }
-      - name: Update FORCE_DRUPAL_BUILD variable
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            await github.rest.actions.updateRepoVariable({
-              owner: 'pentesttoolscom',
-              repo: 'Pentest-Tools.com',
-              name: 'FORCE_DRUPAL_BUILD',
-              value: '${{ steps.git-check.outputs.changes }}'
-            });
+      # TODO: Create token to update the variable
+      # - name: Update FORCE_DRUPAL_BUILD variable
+      #   uses: actions/github-script@v7
+      #   with:
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     script: |
+      #       await github.rest.actions.updateRepoVariable({
+      #         owner: 'pentesttoolscom',
+      #         repo: 'Pentest-Tools.com',
+      #         name: 'FORCE_DRUPAL_BUILD',
+      #         value: '${{ steps.git-check.outputs.changes }}'
+      #       });

--- a/.github/workflows/update_drupal_fingerprint.yml
+++ b/.github/workflows/update_drupal_fingerprint.yml
@@ -89,3 +89,14 @@ jobs:
             {
               "link": ${{ toJson(steps.cpr.outputs.pull-request-url) }}
             }
+      - name: Update FORCE_DRUPAL_BUILD variable
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.updateRepoVariable({
+              owner: 'pentesttoolscom',
+              repo: 'Pentest-Tools.com',
+              variable_name: 'FORCE_DRUPAL_BUILD',
+              value: '${{ steps.git-check.outputs.changes }}'
+            });

--- a/.github/workflows/update_drupal_fingerprint.yml
+++ b/.github/workflows/update_drupal_fingerprint.yml
@@ -38,9 +38,12 @@ jobs:
       - name: Check for changes
         id: git-check
         run: |
-          git diff --exit-code --quiet dscan/plugins/drupal/versions.xml || echo "changes=true" >> $GITHUB_OUTPUT
-          if [ "$?" -ne 0 ]; then
+          if ! git diff --exit-code --quiet dscan/plugins/drupal/versions.xml; then
+            echo "changes=true" >> $GITHUB_OUTPUT
             echo "Changes detected in dscan/plugins/drupal/versions.xml"
+          else
+            echo "changes=false" >> $GITHUB_OUTPUT
+            echo "No changes detected in dscan/plugins/drupal/versions.xml"
           fi
 
       - name: Create Pull Request
@@ -75,5 +78,5 @@ jobs:
         with:
           payload: |
             {
-              "link": ${{ toJson(steps.cpr.outputs.pull-request-url) }},
+              "link": ${{ toJson(steps.cpr.outputs.pull-request-url) }}
             }

--- a/.github/workflows/update_drupal_fingerprint.yml
+++ b/.github/workflows/update_drupal_fingerprint.yml
@@ -61,7 +61,7 @@ jobs:
         id: cpr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: update Drupal fingerprints with new versions"
+          commit-message: "chore[bot]: update Drupal fingerprints with new versions"
           title: "Update Drupal Fingerprints - New Versions Detected"
           body: |
             ## Automated Drupal Fingerprint Update
@@ -77,8 +77,8 @@ jobs:
           delete-branch: true
           add-paths: |
             dscan/plugins/drupal/versions.xml
-          committer: Drupal Update Automation <drupal-bot@pentesttools.com>
-          author: Drupal Update Automation <drupal-bot@pentesttools.com>
+          committer: Drupal Update Automation <108682220+mihai-pasca@users.noreply.github.com>
+          author: Drupal Update Automation <108682220+mihai-pasca@users.noreply.github.com>
           signoff: true
 
       - name: Send GitHub Action trigger data to Slack workflow

--- a/.github/workflows/update_drupal_fingerprint.yml
+++ b/.github/workflows/update_drupal_fingerprint.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   update_drupal_fingerprint:
-    runs-on: ubuntu-22:04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/update_drupal_fingerprint.yml
+++ b/.github/workflows/update_drupal_fingerprint.yml
@@ -35,6 +35,10 @@ jobs:
           chmod +x ./create_hash_file.sh
           ./create_hash_file.sh
 
+      - name: Add test line to versions.xml
+        run: |
+          echo "<!-- Test line added on $(date) -->" >> dscan/plugins/drupal/versions.xml
+
       - name: Check for changes
         id: git-check
         run: |

--- a/.github/workflows/update_drupal_fingerprint.yml
+++ b/.github/workflows/update_drupal_fingerprint.yml
@@ -46,6 +46,15 @@ jobs:
             echo "No changes detected in dscan/plugins/drupal/versions.xml"
           fi
 
+      - name: Setup GPG
+        if: steps.git-check.outputs.changes == 'true'
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
       - name: Create Pull Request
         if: steps.git-check.outputs.changes == 'true'
         uses: peter-evans/create-pull-request@v5
@@ -68,6 +77,9 @@ jobs:
           delete-branch: true
           add-paths: |
             dscan/plugins/drupal/versions.xml
+          committer: Drupal Update Automation <drupal-bot@pentesttools.com>
+          author: Drupal Update Automation <drupal-bot@pentesttools.com>
+          signoff: true
 
       - name: Send GitHub Action trigger data to Slack workflow
         if: steps.git-check.outputs.changes == 'true'

--- a/.github/workflows/update_drupal_fingerprint.yml
+++ b/.github/workflows/update_drupal_fingerprint.yml
@@ -61,6 +61,7 @@ jobs:
 
             Please review and merge if the changes look correct.
           branch: update-drupal-fingerprints-${{ github.run_number }}
+          base: ${{ github.event.repository.default_branch }}
           delete-branch: true
           add-paths: |
             dscan/plugins/drupal/versions.xml

--- a/.github/workflows/update_drupal_fingerprint.yml
+++ b/.github/workflows/update_drupal_fingerprint.yml
@@ -1,6 +1,7 @@
 name: "Update Drupal Fingerprint"
 
 on:
+  pull_request:
   workflow_dispatch:
   schedule:
     # Run every Monday at 10:00 AM Romania time (8:00 AM UTC)

--- a/.github/workflows/update_drupal_fingerprint.yml
+++ b/.github/workflows/update_drupal_fingerprint.yml
@@ -97,6 +97,6 @@ jobs:
             await github.rest.actions.updateRepoVariable({
               owner: 'pentesttoolscom',
               repo: 'Pentest-Tools.com',
-              variable_name: 'FORCE_DRUPAL_BUILD',
+              name: 'FORCE_DRUPAL_BUILD',
               value: '${{ steps.git-check.outputs.changes }}'
             });

--- a/.github/workflows/update_drupal_fingerprint.yml
+++ b/.github/workflows/update_drupal_fingerprint.yml
@@ -1,7 +1,6 @@
 name: "Update Drupal Fingerprint"
 
 on:
-  pull_request:
   workflow_dispatch:
   schedule:
     # Run every Monday at 10:00 AM EEST and 9:00 AM EET (7:00 AM UTC)
@@ -34,10 +33,6 @@ jobs:
         run: |
           chmod +x ./create_hash_file.sh
           ./create_hash_file.sh
-
-      - name: Add test line to versions.xml
-        run: |
-          echo "<!-- Test line added on $(date) -->" >> dscan/plugins/drupal/versions.xml
 
       - name: Check for changes
         id: git-check
@@ -73,7 +68,8 @@ jobs:
             This PR was automatically created because new Drupal versions were detected.
 
             Please check the versions.xml file to make sure the format is fine and merge if everything is OK.
-            After merging, the FORCE_DRUPAL_BUILD also needs to be updated to true, atm it is not done automatically.
+
+            After merging, the FORCE_DRUPAL_BUILD variable needs to be updated to true on the main repo (atm it is not done automatically).
           branch: update-drupal-fingerprints-${{ github.run_number }}
           base: ${{ github.event.repository.default_branch }}
           delete-branch: true

--- a/.github/workflows/update_drupal_fingerprint.yml
+++ b/.github/workflows/update_drupal_fingerprint.yml
@@ -1,0 +1,77 @@
+name: "Update Drupal Fingerprint"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run every Monday at 10:00 AM Romania time (8:00 AM UTC)
+    - cron: "0 8 * * 1"
+
+jobs:
+  update_drupal_fingerprint:
+    runs-on: ubuntu-22:04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests
+
+      - name: Run create_hash_file.sh
+        run: |
+          chmod +x ./create_hash_file.sh
+          ./create_hash_file.sh
+
+      - name: Check for changes
+        id: git-check
+        run: |
+          git diff --exit-code --quiet dscan/plugins/drupal/versions.xml || echo "changes=true" >> $GITHUB_OUTPUT
+          if [ "$?" -ne 0 ]; then
+            echo "Changes detected in dscan/plugins/drupal/versions.xml"
+          fi
+
+      - name: Create Pull Request
+        if: steps.git-check.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v5
+        id: cpr
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update Drupal fingerprints with new versions"
+          title: "Update Drupal Fingerprints - New Versions Detected"
+          body: |
+            ## Automated Drupal Fingerprint Update
+
+            This PR was automatically created because new Drupal versions were detected.
+
+            ### Changes:
+            - Updated Drupal version fingerprints
+
+            Please review and merge if the changes look correct.
+          branch: update-drupal-fingerprints-${{ github.run_number }}
+          delete-branch: true
+          add-paths: |
+            dscan/plugins/drupal/versions.xml
+
+      - name: Send GitHub Action trigger data to Slack workflow
+        if: steps.git-check.outputs.changes == 'true'
+        id: slack
+        uses: slackapi/slack-github-action@v1.25.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_DRUPAL_FINGERPRINT}}
+        with:
+          payload: |
+            {
+              "link": ${{ toJson(steps.cpr.outputs.pull-request-url) }},
+            }


### PR DESCRIPTION
Action that creates PR:
https://github.com/pentesttoolscom/droopescan/actions/runs/17646789877?pr=6
PR:
https://github.com/pentesttoolscom/droopescan/pull/10
Slack message sent:
https://pentest-tools-com.slack.com/archives/C03M7G7LWE9/p1757587960204679

Action that did not find differences after the PR was merged:
https://github.com/pentesttoolscom/droopescan/actions/runs/17648003726?pr=6

⚠️ Do not merge in this version, I have to remove it from running in the Pull Request Workflow
Note: the variable change on the main repo doesn't work because the workflow does not have the required token
If it's fine to add it we can do it, if not I think it's fine to update the variable manually because it's pretty simple.