### PR TITLE
feat: add automation for drupal force variable update

### DIFF
--- a/.github/workflows/on_drupal_fingerprint_merge.yml
+++ b/.github/workflows/on_drupal_fingerprint_merge.yml
@@ -1,0 +1,26 @@
+name: "On Drupal Fingerprint Merge"
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_force_drupal_build:
+    if: startsWith(github.head_ref, 'update-drupal-fingerprints-')
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Update FORCE_DRUPAL_BUILD variable
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PENTESTTOOLS_COM_TOKEN }}
+          script: |
+            await github.rest.actions.updateRepoVariable({
+              owner: 'pentesttoolscom',
+              repo: 'Pentest-Tools.com',
+              name: 'FORCE_DRUPAL_BUILD',
+              value: 'true'
+            });
+
+      - name: Log success
+        run: echo "FORCE_DRUPAL_BUILD variable has been set to true"

--- a/.github/workflows/on_drupal_fingerprint_merge.yml
+++ b/.github/workflows/on_drupal_fingerprint_merge.yml
@@ -6,9 +6,6 @@ on:
       - master
     paths:
       - 'dscan/plugins/drupal/versions.xml'
-  pull_request:
-    paths:
-      - 'dscan/plugins/drupal/versions.xml'
 
 jobs:
   update_force_drupal_build:

--- a/.github/workflows/on_drupal_fingerprint_merge.yml
+++ b/.github/workflows/on_drupal_fingerprint_merge.yml
@@ -4,10 +4,11 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'dscan/plugins/drupal/versions.xml'
 
 jobs:
   update_force_drupal_build:
-    if: contains(github.event.head_commit.modified, 'dscan/plugins/drupal/versions.xml')
     runs-on: ubuntu-22.04
     steps:
       - name: Update FORCE_DRUPAL_BUILD variable

--- a/.github/workflows/on_drupal_fingerprint_merge.yml
+++ b/.github/workflows/on_drupal_fingerprint_merge.yml
@@ -6,6 +6,9 @@ on:
       - master
     paths:
       - 'dscan/plugins/drupal/versions.xml'
+  pull_request:
+    paths:
+      - 'dscan/plugins/drupal/versions.xml'
 
 jobs:
   update_force_drupal_build:

--- a/.github/workflows/on_drupal_fingerprint_merge.yml
+++ b/.github/workflows/on_drupal_fingerprint_merge.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update_force_drupal_build:
-    if: startsWith(github.head_ref, 'update-drupal-fingerprints-')
+    if: contains(github.event.head_commit.modified, 'dscan/plugins/drupal/versions.xml')
     runs-on: ubuntu-22.04
     steps:
       - name: Update FORCE_DRUPAL_BUILD variable

--- a/.github/workflows/update_drupal_fingerprint.yml
+++ b/.github/workflows/update_drupal_fingerprint.yml
@@ -100,5 +100,5 @@ jobs:
               owner: 'pentesttoolscom',
               repo: 'Pentest-Tools.com',
               name: 'FORCE_DRUPAL_BUILD',
-              value: 'false'
+              value: 'true'
             });

--- a/.github/workflows/update_drupal_fingerprint.yml
+++ b/.github/workflows/update_drupal_fingerprint.yml
@@ -5,9 +5,7 @@ on:
   schedule:
     # Run every Monday at 10:00 AM EEST and 9:00 AM EET (7:00 AM UTC)
     - cron: "0 7 * * 1"
-  pull_request:
-    types: [opened]
-
+    # trigger the pipeline when creating a PR that needs to be merged to master branch
 
 jobs:
   update_drupal_fingerprint:
@@ -100,5 +98,5 @@ jobs:
               owner: 'pentesttoolscom',
               repo: 'Pentest-Tools.com',
               name: 'FORCE_DRUPAL_BUILD',
-              value: 'true'
+              value: 'false'
             });

--- a/.github/workflows/update_drupal_fingerprint.yml
+++ b/.github/workflows/update_drupal_fingerprint.yml
@@ -5,7 +5,6 @@ on:
   schedule:
     # Run every Monday at 10:00 AM EEST and 9:00 AM EET (7:00 AM UTC)
     - cron: "0 7 * * 1"
-    # trigger the pipeline when creating a PR that needs to be merged to master branch
 
 jobs:
   update_drupal_fingerprint:

--- a/.github/workflows/update_drupal_fingerprint.yml
+++ b/.github/workflows/update_drupal_fingerprint.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     # Run every Monday at 10:00 AM EEST and 9:00 AM EET (7:00 AM UTC)
     - cron: "0 7 * * 1"
+  pull_request:
+    types: [opened]
+
 
 jobs:
   update_drupal_fingerprint:
@@ -68,8 +71,6 @@ jobs:
             This PR was automatically created because new Drupal versions were detected.
 
             Please check the versions.xml file to make sure the format is fine and merge if everything is OK.
-
-            After merging, the FORCE_DRUPAL_BUILD variable needs to be updated to true on the main repo (atm it is not done automatically).
           branch: update-drupal-fingerprints-${{ github.run_number }}
           base: ${{ github.event.repository.default_branch }}
           delete-branch: true
@@ -90,15 +91,14 @@ jobs:
             {
               "link": ${{ toJson(steps.cpr.outputs.pull-request-url) }}
             }
-      # TODO: Create token to update the variable
-      # - name: Update FORCE_DRUPAL_BUILD variable
-      #   uses: actions/github-script@v7
-      #   with:
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
-      #     script: |
-      #       await github.rest.actions.updateRepoVariable({
-      #         owner: 'pentesttoolscom',
-      #         repo: 'Pentest-Tools.com',
-      #         name: 'FORCE_DRUPAL_BUILD',
-      #         value: '${{ steps.git-check.outputs.changes }}'
-      #       });
+      - name: Update FORCE_DRUPAL_BUILD variable
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PENTESTTOOLS_COM_TOKEN }}
+          script: |
+            await github.rest.actions.updateRepoVariable({
+              owner: 'pentesttoolscom',
+              repo: 'Pentest-Tools.com',
+              name: 'FORCE_DRUPAL_BUILD',
+              value: 'false'
+            });

--- a/dscan/plugins/drupal/versions.xml
+++ b/dscan/plugins/drupal/versions.xml
@@ -2,7 +2,7 @@
   <files>
     <file url="misc/drupal.js">
       <version md5="0bfcff7496657c81746165b5b1654bdf" nb="4.7.0" />
-      <version md5="cf802e07e369d11aeab8c289884c0cec" nb="4.7.0-beta-3" />
+      <version md5="cf802e07e369d11aeab8c289884c0ced" nb="4.7.0-beta-3" />
       <version md5="af07ab95646559c3d702814a70157857" nb="4.7.0-beta-4" />
       <version md5="4478df9a594c84570d0526fb74d75998" nb="4.7.0-beta-5" />
       <version md5="4478df9a594c84570d0526fb74d75998" nb="4.7.0-beta-6" />

--- a/dscan/plugins/drupal/versions.xml
+++ b/dscan/plugins/drupal/versions.xml
@@ -2,7 +2,7 @@
   <files>
     <file url="misc/drupal.js">
       <version md5="0bfcff7496657c81746165b5b1654bdf" nb="4.7.0" />
-      <version md5="cf802e07e369d11aeab8c289884c0ced" nb="4.7.0-beta-3" />
+      <version md5="cf802e07e369d11aeab8c289884c0cec" nb="4.7.0-beta-3" />
       <version md5="af07ab95646559c3d702814a70157857" nb="4.7.0-beta-4" />
       <version md5="4478df9a594c84570d0526fb74d75998" nb="4.7.0-beta-5" />
       <version md5="4478df9a594c84570d0526fb74d75998" nb="4.7.0-beta-6" />


### PR DESCRIPTION
Update the force build token automatically when a PR with versions is merged
Set it to false on scheduled run to prevent it from useless forcing the build.

Scheduled workflow test:
https://github.com/pentesttoolscom/droopescan/actions/runs/21446824286?pr=24
The workflow was succesful and the variable was set

Merge workflow test:
https://github.com/pentesttoolscom/droopescan/actions/runs/21472522452?pr=24
The workflow was succesful and the variable was set only when the `versions.xml` file was changed.